### PR TITLE
feat: wide popups

### DIFF
--- a/example/src/utils/sampleData.ts
+++ b/example/src/utils/sampleData.ts
@@ -12,23 +12,23 @@ export const emojiArr1 = [
     content: "🤔",
   },
   {
-    name: "Heart",
-    content: "❤️",
+    name: "Screaming",
+    content: "😱",
   },
   {
-    name: "Laughing",
-    content: "😂",
-  },
-  {
-    name: "Crying",
-    content: "😢",
-  },
-  {
-    name: "Thinking",
-    content: "🤔",
+    name: "Eyes",
+    content: "👀",
   },
   {
     name: "Heart",
     content: "❤️",
+  },
+  {
+    name: "Thumbs up",
+    content: "👍",
+  },
+  {
+    name: "Thumbs down",
+    content: "👎",
   },
 ];

--- a/src/components/ReactionPopover/ReactionPopover.tsx
+++ b/src/components/ReactionPopover/ReactionPopover.tsx
@@ -25,6 +25,7 @@ export const ReactionPopover = (props: PopoverProps) => {
     hideHeader,
     hideCloseButton,
     disableClickAwayToClose,
+    wide,
   } = props;
   const [isPopoverVisible, setIsPopoverVisible] = useState(isVisible);
   const [popoverHeader, setPopoverHeader] = useState(headerAlt);
@@ -49,6 +50,7 @@ export const ReactionPopover = (props: PopoverProps) => {
         className={"rqr-outer-div " + outerDivClass}
         visible={isPopoverVisible}
         hideHeader={hideHeader}
+        wide={wide}
       >
         {!hideCloseButton && (
           <CloseButton

--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -9,12 +9,28 @@ export const Overlay = styled.div`
   z-index: 2000000000; // This is what Google does, so it's okay.
 `;
 
-export const OuterDiv = styled.div<{ visible: boolean; hideHeader?: boolean }>`
-  width: 160px;
-  height: ${({ hideHeader }) => (hideHeader ? "70px" : "100px")};
+const calcHeight = (hideHeader?: boolean, wide?: boolean) => {
+  if (hideHeader) {
+    if (wide) return 35;
+    else return 68;
+  } else {
+    if (wide) return 54;
+    // Default height.
+    else return 90;
+  }
+};
+
+export const OuterDiv = styled.div<{
+  visible: boolean;
+  hideHeader?: boolean;
+  wide?: boolean;
+}>`
+  width: ${({ wide }) => (wide ? "275px" : "136px")};
+  height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide)}px;
+  overflow: hidden;
   position: absolute;
-  bottom: 40px;
-  left: 7px;
+  top: 10px;
+  left: 10px;
   padding: 8px;
   border-radius: 4px;
   background: white;
@@ -23,20 +39,20 @@ export const OuterDiv = styled.div<{ visible: boolean; hideHeader?: boolean }>`
   visibility: ${({ visible }) => (visible ? "visible" : "hidden")};
   opacity: ${({ visible }) => (visible ? "1" : "0")};
   transition: opacity 0.15s;
-  animation: ${({ visible }) => visible && "PopoverBounce 0.1s ease-in 1"};
   z-index: 2000000000; // This is what Google does, so it's okay.
+  animation: ${({ visible }) => visible && "PopoverBounce 0.1s ease-in 1"};
 
   @keyframes PopoverBounce {
     from {
-      height: 80px;
+      height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide) - 20}px;
     }
     to {
-      height: 110px;
+      height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide) + 10}px;
     }
   }
 `;
 
-export const CloseButton = styled.span`
+export const CloseButton = styled.span` bool
   color: lightgrey;
   position: absolute;
   top: 4px;

--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -52,7 +52,7 @@ export const OuterDiv = styled.div<{
   }
 `;
 
-export const CloseButton = styled.span` bool
+export const CloseButton = styled.span`
   color: lightgrey;
   position: absolute;
   top: 4px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,4 +19,5 @@ export interface PopoverProps {
   hideHeader?: boolean;
   hideCloseButton?: boolean;
   disableClickAwayToClose?: boolean;
+  wide?: boolean;
 }


### PR DESCRIPTION
### Summary
Added new feature to support wide popups. Shows 8 emojis in a row.

### Why this change is needed
Wide emoji popups are used in many sites, wanted to add built-in support for this format

### What was done
* Added `wide` prop to component
* Variable popup height, depending on `hideHeader` and `wide`
* Fixed the bounce animation to account for the new height possibilities
* Changed some emojis in the example's sample array