### PR TITLE
feat: wide popup adjusts width according to number of emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quick-reactions",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A popup emoji-reaction component for React.",
   "private": false,
   "main": "./lib/cjs/index.js",

--- a/src/components/ReactionPopover/ReactionPopover.tsx
+++ b/src/components/ReactionPopover/ReactionPopover.tsx
@@ -42,11 +42,13 @@ export const ReactionPopover = (props: PopoverProps) => {
         visible={isVisible}
         hideHeader={hideHeader}
         wide={wide}
+        arrayLength={reactionsArray.length}
       >
         {!hideCloseButton && (
           <CloseButton
             className={"rqr-close-button " + closeButtonClassName}
             onClick={onClose}
+            wide={wide}
           >
             {closeButton ? closeButton : <CloseSvg />}
           </CloseButton>

--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -9,6 +9,14 @@ export const Overlay = styled.div`
   z-index: 2000000000; // This is what Google does, so it's okay.
 `;
 
+// Calculate width of `wide` popup.
+const calcWidth = (arrayLength: number) => {
+  if (arrayLength > 8) arrayLength = 8;
+  // (34px per item) + 17px
+  return 34 * arrayLength + 17;
+};
+
+// Calculates height according to `wide` and `header` state.
 const calcHeight = (hideHeader?: boolean, wide?: boolean) => {
   if (hideHeader) {
     if (wide) return 35;
@@ -24,8 +32,10 @@ export const OuterDiv = styled.div<{
   visible: boolean;
   hideHeader?: boolean;
   wide?: boolean;
+  arrayLength: number;
 }>`
-  width: ${({ wide }) => (wide ? "275px" : "136px")};
+  width: ${({ wide, arrayLength = 8 }) =>
+    wide ? calcWidth(arrayLength) + "px" : "136px"};
   height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide)}px;
   overflow: hidden;
   position: absolute;
@@ -50,10 +60,10 @@ export const OuterDiv = styled.div<{
   }
 `;
 
-export const CloseButton = styled.span`
+export const CloseButton = styled.span<{ wide?: boolean }>`
   position: absolute;
   top: 4px;
-  right: 8px;
+  right: ${({ wide }) => (wide ? 4 : 8)}px;
   font-size: 0.8rem;
   cursor: pointer;
   font-weight: bold;


### PR DESCRIPTION
### Summary
1. Popups with `wide` will now adjust length according to the number of items in `reactionsArray` (for up to eight items).
2. Fixed the position of the wide popup's close button, as it was clipping with the last item's container.

### Why this change is needed
1. Clean, automatic styling. Easier for setup.
2. Style balance.

### What was done
1. Added function to calculate width based on number of emojis in `reactionsArray`.
2. Added conditional to `CloseButton` to determine `right` positioning.