### PR TITLE
style: `calcWidth`, `calcHeight` update

### DIFF
--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -17,14 +17,18 @@ const calcWidth = (arrayLength: number) => {
   return 34 * arrayLength + 17;
 };
 
-// Calculates height according to `wide` and `header` state.
-const calcHeight = (hideHeader?: boolean, wide?: boolean) => {
+// Calculates height according to `wide`, `header`, and reactionArray.length.
+const calcHeight = (
+  arrayLength: number,
+  hideHeader?: boolean,
+  wide?: boolean
+) => {
   if (hideHeader) {
-    if (wide) return 35;
+    if (wide || arrayLength < 5) return 35;
     else return 68;
   } else {
-    if (wide) return 54;
-    // Default height.
+    if (wide || arrayLength < 5) return 54;
+    // Default popup height is 90.
     else return 90;
   }
 };
@@ -37,7 +41,8 @@ export const OuterDiv = styled.div<{
 }>`
   width: ${({ wide, arrayLength = 8 }) =>
     wide ? calcWidth(arrayLength) + "px" : "136px"};
-  height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide)}px;
+  height: ${({ hideHeader, wide, arrayLength }) =>
+    calcHeight(arrayLength, hideHeader, wide)}px;
   overflow: hidden;
   position: absolute;
   padding: 8px;
@@ -53,10 +58,12 @@ export const OuterDiv = styled.div<{
 
   @keyframes PopoverBounce {
     from {
-      height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide) - 20}px;
+      height: ${({ hideHeader, wide, arrayLength }) =>
+        calcHeight(arrayLength, hideHeader, wide) - 20}px;
     }
     to {
-      height: ${({ hideHeader, wide }) => calcHeight(hideHeader, wide) + 10}px;
+      height: ${({ hideHeader, wide, arrayLength }) =>
+        calcHeight(arrayLength, hideHeader, wide) + 10}px;
     }
   }
 `;

--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -12,6 +12,7 @@ export const Overlay = styled.div`
 // Calculate width of `wide` popup.
 const calcWidth = (arrayLength: number) => {
   if (arrayLength > 8) arrayLength = 8;
+  if (arrayLength === 0) arrayLength = 1;
   // (34px per item) + 17px
   return 34 * arrayLength + 17;
 };


### PR DESCRIPTION
### Summary
Updated `calcWidth` and `calcHeight` functions based on #21. A popup with a `reactionArray` of only four items will now effectively look the same, regardless of `wide`.

### Why this change is needed
With only the changes made in #21, the functionality felt incomplete, as the same feature was not implemented in the tall version of the popup.

### What was done
* If `reactionArray` is a length of `0`, `calcWidth` defaults to a width of one item wide. 
* If the are fewer than five items in `reactionArray`, the height of a default, non-`wide` popup will now adjust to be shorter.