### PR TITLE
feat: animations

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://dylandbl.github.io/react-quick-reactions",
   "private": true,
   "dependencies": {

--- a/example/src/components/showcaseComponents/config/Config.tsx
+++ b/example/src/components/showcaseComponents/config/Config.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import QuickReactions from "react-quick-reactions";
-import { PlacementType } from "../../../../../lib/esm/types";
-import { emojiArr1, positionOptions } from "../../../utils/sampleData";
+import { AnimationType, PlacementType } from "../../../../../lib/esm/types";
+import {
+  animationOptions,
+  emojiArr1,
+  positionOptions,
+} from "../../../utils/sampleData";
 import { GridItem } from "../gridShowcase/GridShowcaseStyles";
 import { ConfigButton, ConfigContainer, InputsContainer } from "./ConfigStyles";
 
@@ -14,6 +18,7 @@ export const Config = () => {
   const [hideCloseButton, setHideCloseButton] = useState(false);
   const [wide, setWide] = useState(false);
   const [disableClickAwayToClose, setDisableClickAwayToClose] = useState(false);
+  const [animation, setAnimation] = useState<AnimationType>("drop");
 
   return (
     <>
@@ -24,6 +29,7 @@ export const Config = () => {
         onClose={() => {
           setShowPopup(false);
         }}
+        animation={animation}
         reactionsArray={emojiArr1}
         hideHeader={hideHeader}
         hideCloseButton={hideCloseButton}
@@ -58,6 +64,23 @@ export const Config = () => {
             onChange={(e) => setPlacement(e.target.value as PlacementType)}
           >
             {positionOptions.map((item, index) => (
+              <option key={item + "-" + index}>{item}</option>
+            ))}
+          </select>
+          <br />
+
+          <label htmlFor="animation" className="dropdownLabel">
+            Animation
+          </label>
+          <br />
+          <select
+            id="animation"
+            name="animation"
+            className="dropdownLabel"
+            value={animation}
+            onChange={(e) => setAnimation(e.target.value as AnimationType)}
+          >
+            {animationOptions.map((item, index) => (
               <option key={item + "-" + index}>{item}</option>
             ))}
           </select>

--- a/example/src/utils/sampleData.ts
+++ b/example/src/utils/sampleData.ts
@@ -1,4 +1,4 @@
-import { PlacementType } from "../../../lib/esm/types";
+import { AnimationType, PlacementType } from "../../../lib/esm/types";
 
 export const emojiArr1 = [
   {
@@ -98,4 +98,11 @@ export const positionOptions: PlacementType[] = [
   "bottom-start",
   "bottom",
   "bottom-end",
+];
+
+export const animationOptions: AnimationType[] = [
+  "drop",
+  "fade",
+  "flip",
+  "none",
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quick-reactions",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A popup emoji-reaction component for React.",
   "private": false,
   "main": "./lib/cjs/index.js",

--- a/src/components/ReactionPopover/ReactionPopover.tsx
+++ b/src/components/ReactionPopover/ReactionPopover.tsx
@@ -6,6 +6,7 @@ import {
   SelectionContainer,
   ReactionElement,
   Overlay,
+  PopupPositioningWrapper,
 } from "../../styles/ReactionPopoverStyles";
 import { RQRProps } from "../../types";
 import { CloseSvg } from "../svg/CloseSvg";
@@ -27,6 +28,7 @@ interface PopoverProps extends RQRProps {
 
 export const ReactionPopover = (props: PopoverProps) => {
   const {
+    animation = "drop",
     isVisible = false,
     onClickReaction,
     closeButton,
@@ -54,68 +56,77 @@ export const ReactionPopover = (props: PopoverProps) => {
   return (
     <>
       {!disableClickAwayToClose && isVisible && <Overlay onClick={onClose} />}
-      <OuterDiv
+      <PopupPositioningWrapper
         triggerTransformValues={triggerTransformValues}
         placement={placement}
-        className={
-          "rqr-outer-div" + (outerDivClassName ? " " + outerDivClassName : "")
-        }
-        visible={isVisible}
         hideHeader={hideHeader}
         wide={wide}
         arrayLength={reactionsArray.length}
       >
-        {!hideHeader && (
-          <Header
-            className={
-              "rqr-header" + (headerClassName ? " " + headerClassName : "")
-            }
-          >
-            {popoverHeader}
-          </Header>
-        )}
-
-        {!hideCloseButton && (
-          <CloseButton
-            className={
-              "rqr-close-button" +
-              (closeButtonClassName ? " " + closeButtonClassName : "")
-            }
-            onClick={onClose}
-            wide={wide}
-          >
-            {closeButton ? closeButton : <CloseSvg />}
-          </CloseButton>
-        )}
-        <SelectionContainer
+        <OuterDiv
           className={
-            "rqr-selection-container" +
-            (selectionContainerClassName
-              ? " " + selectionContainerClassName
-              : "")
+            "rqr-outer-div" + (outerDivClassName ? " " + outerDivClassName : "")
           }
+          visible={isVisible}
+          hideHeader={hideHeader}
+          wide={wide}
+          arrayLength={reactionsArray.length}
+          animation={animation}
         >
-          {reactionsArray?.map((item, index) => (
-            <ReactionElement
+          {!hideHeader && (
+            <Header
               className={
-                "rqr-reaction-element" +
-                (reactionElementClassName ? " " + reactionElementClassName : "")
+                "rqr-header" + (headerClassName ? " " + headerClassName : "")
               }
-              key={item?.name + "-" + index}
-              id={item?.id}
-              onClick={(e) => onClickReaction(e.target as Element)}
-              onMouseEnter={
-                changeHeaderOnReactionElemHover
-                  ? () => setPopoverHeader(item?.name)
-                  : () => undefined
-              }
-              onMouseLeave={resetHeader}
             >
-              {item?.content}
-            </ReactionElement>
-          ))}
-        </SelectionContainer>
-      </OuterDiv>
+              {popoverHeader}
+            </Header>
+          )}
+
+          {!hideCloseButton && (
+            <CloseButton
+              className={
+                "rqr-close-button" +
+                (closeButtonClassName ? " " + closeButtonClassName : "")
+              }
+              onClick={onClose}
+              wide={wide}
+            >
+              {closeButton ? closeButton : <CloseSvg />}
+            </CloseButton>
+          )}
+          <SelectionContainer
+            className={
+              "rqr-selection-container" +
+              (selectionContainerClassName
+                ? " " + selectionContainerClassName
+                : "")
+            }
+          >
+            {reactionsArray?.map((item, index) => (
+              <ReactionElement
+                className={
+                  "rqr-reaction-element" +
+                  (reactionElementClassName
+                    ? " " + reactionElementClassName
+                    : "")
+                }
+                key={item?.name + "-" + index}
+                id={item?.id}
+                onClick={(e) => onClickReaction(e.target as Element)}
+                onMouseEnter={
+                  changeHeaderOnReactionElemHover
+                    ? () => setPopoverHeader(item?.name)
+                    : () => undefined
+                }
+                onMouseLeave={resetHeader}
+              >
+                {item?.content}
+              </ReactionElement>
+            ))}
+          </SelectionContainer>
+        </OuterDiv>
+      </PopupPositioningWrapper>
     </>
   );
 };

--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { TransformValuesType } from "../components/ReactionPopover/ReactionPopover";
-import { PlacementType } from "../types";
+import { AnimationType, PlacementType } from "../types";
 import { calculatePopupTranslate, calcWidth, calcHeight } from "./styleUtils";
 
 export const Overlay = styled.div`
@@ -13,13 +13,36 @@ export const Overlay = styled.div`
   z-index: 2000000000; // This is what Google does, so it's okay.
 `;
 
-export const OuterDiv = styled.div<{
-  visible: boolean;
+// Separating the placement calculation from the rest of OuterDiv allows me to use transform for animations.
+export const PopupPositioningWrapper = styled.div<{
   hideHeader?: boolean;
   wide?: boolean;
   arrayLength: number;
   triggerTransformValues?: TransformValuesType;
   placement: PlacementType;
+}>`
+  ${({ triggerTransformValues, placement, arrayLength, hideHeader, wide }) =>
+    triggerTransformValues &&
+    css`
+      transform: translate(
+        ${calculatePopupTranslate(
+          triggerTransformValues,
+          // This solution assumes the height and width are calculated based on the standards I defined,
+          // not on actual height/width, which could be changed by the user.
+          wide ? calcWidth(arrayLength) : 150,
+          calcHeight(arrayLength, hideHeader, wide),
+          placement
+        )}
+      );
+    `}
+`;
+
+export const OuterDiv = styled.div<{
+  visible: boolean;
+  hideHeader?: boolean;
+  wide?: boolean;
+  arrayLength: number;
+  animation: AnimationType;
 }>`
   width: ${({ wide, arrayLength = 8 }) =>
     wide ? calcWidth(arrayLength) + "px" : "150px"};
@@ -38,22 +61,9 @@ export const OuterDiv = styled.div<{
   visibility: ${({ visible }) => (visible ? "visible" : "hidden")};
   opacity: ${({ visible }) => (visible ? "1" : "0")};
   transition: opacity 0.15s;
-  animation: ${({ visible }) => visible && "drop 0.1s ease-in 1"};
 
-  ${({ triggerTransformValues, placement, arrayLength, hideHeader, wide }) =>
-    triggerTransformValues &&
-    css`
-      transform: translate(
-        ${calculatePopupTranslate(
-          triggerTransformValues,
-          // This solution assumes the height and width are calculated based on the standards I defined,
-          // not on actual height/width, which could be changed by the user.
-          wide ? calcWidth(arrayLength) : 150,
-          calcHeight(arrayLength, hideHeader, wide),
-          placement
-        )}
-      );
-    `}
+  animation: ${({ visible, animation }) =>
+    visible && `${animation} 0.1s ease-in 1`};
 
   @keyframes drop {
     from {
@@ -63,6 +73,35 @@ export const OuterDiv = styled.div<{
     to {
       height: ${({ hideHeader, wide, arrayLength }) =>
         calcHeight(arrayLength, hideHeader, wide) + 10}px;
+    }
+  }
+
+  @keyframes fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes flip {
+    0% {
+      perspective: 500px;
+      transform: rotateX(70deg);
+    }
+    100% {
+      perspective: 500px;
+      transform: rotateX(-35deg);
+    }
+  }
+
+  @keyframes zoom {
+    from {
+      transform: scale(0, 0);
+    }
+    to {
+      transform: scale(1, 1);
     }
   }
 `;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,10 @@ export type PlacementType =
   | "bottom"
   | "bottom-end";
 
+export type AnimationType = "drop" | "fade" | "flip" | "zoom" | "none";
+
 export interface RQRProps {
+  animation?: AnimationType;
   changeHeaderOnReactionElemHover?: boolean;
   closeButton?: string | JSX.Element;
   closeButtonClassName?: string;


### PR DESCRIPTION
### Summary
Added new transition animations for popup appearance.

### Why this change is needed
In the event the user doesn't like the default `drop` animation, they can easily choose another without having to develop it themselves.

### What was done
* Created a wrapper div for the popup and moved the position calculation into it. This allowed me to free `transform` for use in animations in the popup.
* Added new animations.