### PR TITLE
feat(example): new codeblock

### DIFF
--- a/example/src/components/showcaseComponents/codblock/Codeblock.tsx
+++ b/example/src/components/showcaseComponents/codblock/Codeblock.tsx
@@ -1,0 +1,47 @@
+import { CopiedNotice, Pre, CodeblockContainer } from "./CodeblockStyles";
+import { SVG } from "../../svgs/SVGStyles";
+
+export const Codeblock = ({
+  children,
+  show = true,
+}: {
+  children: string | string[];
+  show?: boolean;
+}) => {
+  const handleCopy = () => {
+    const codeContent = Array.isArray(children) ? children.join("") : children;
+    // Copy text to clipboard.
+    navigator.clipboard.writeText(codeContent);
+
+    const copiedNotice = document.getElementById("copiedNotice");
+    copiedNotice?.classList.remove("animateCopied");
+    void copiedNotice?.offsetWidth; // Triggers a reflow.
+    copiedNotice?.classList.add("animateCopied");
+  };
+
+  return (
+    <CodeblockContainer>
+      <CopiedNotice id="copiedNotice">Copied!</CopiedNotice>
+      <Pre show={show}>
+        <SVG
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 16 16"
+          width="16"
+          height="16"
+          className={"copyIcon"}
+          onClick={handleCopy}
+        >
+          <path
+            fillRule="evenodd"
+            d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"
+          ></path>
+          <path
+            fillRule="evenodd"
+            d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"
+          ></path>
+        </SVG>
+        <code id="codeContent">{children}</code>
+      </Pre>
+    </CodeblockContainer>
+  );
+};

--- a/example/src/components/showcaseComponents/codblock/CodeblockStyles.ts
+++ b/example/src/components/showcaseComponents/codblock/CodeblockStyles.ts
@@ -1,0 +1,50 @@
+import styled from "@emotion/styled";
+
+export const CodeblockContainer = styled.div``;
+
+export const Pre = styled.pre<{ show: boolean }>`
+  background: #e7e7e7;
+  border-radius: 4px;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
+  height: 100%;
+  position: relative;
+  margin: 0;
+
+  width: 100%;
+  padding: 4px 12px 8px;
+  overflow-x: hidden;
+
+  .copyIcon {
+    position: absolute;
+    right: 10px;
+    top: 8px;
+    :active {
+      fill: #bf2abf;
+    }
+  }
+`;
+
+export const CopiedNotice = styled.span`
+  font-size: 0.8rem;
+  font-weight: 500;
+  position: relative;
+  width: 0;
+  opacity: 0;
+  float: right;
+  right: 42px;
+
+  &.animateCopied {
+    animation: copiedAnimation 1s;
+  }
+  @keyframes copiedAnimation {
+    from {
+      top: -22px;
+      opacity: 1;
+    }
+    to {
+      top: -60px;
+      opacity: 0;
+    }
+  }
+`;

--- a/example/src/components/showcaseComponents/config/Config.tsx
+++ b/example/src/components/showcaseComponents/config/Config.tsx
@@ -6,11 +6,11 @@ import {
   emojiArr1,
   positionOptions,
 } from "../../../utils/sampleData";
+import { Codeblock } from "../codblock/Codeblock";
 import { GridItem } from "../gridShowcase/GridShowcaseStyles";
-import { ConfigButton, ConfigContainer, InputsContainer } from "./ConfigStyles";
+import { ConfigContainer, InputsContainer } from "./ConfigStyles";
 
 export const Config = () => {
-  const [showConfig, setShowConfig] = useState(false);
   const [showPopup, setShowPopup] = useState(false);
   // Config states.
   const [placement, setPlacement] = useState<PlacementType>("right");
@@ -19,39 +19,13 @@ export const Config = () => {
   const [wide, setWide] = useState(false);
   const [disableClickAwayToClose, setDisableClickAwayToClose] = useState(false);
   const [animation, setAnimation] = useState<AnimationType>("drop");
+  const [emojiArrLength, setEmojiArrLength] = useState(8);
 
   return (
     <>
-      <h2 style={{ marginBottom: "32px" }}>Customize it</h2>
-      <QuickReactions
-        onClickReaction={() => {}}
-        isVisible={showPopup}
-        onClose={() => {
-          setShowPopup(false);
-        }}
-        animation={animation}
-        reactionsArray={emojiArr1}
-        hideHeader={hideHeader}
-        hideCloseButton={hideCloseButton}
-        placement={placement}
-        wide={wide}
-        disableClickAwayToClose={disableClickAwayToClose}
-        trigger={
-          <GridItem
-            hasTitle
-            onClick={() => {
-              setShowPopup(!showPopup);
-            }}
-          >
-            Click me!
-          </GridItem>
-        }
-      />
+      <h2 style={{ marginTop: "32px" }}>Configure it</h2>
       <ConfigContainer>
-        <ConfigButton onClick={() => setShowConfig(!showConfig)}>
-          Configure
-        </ConfigButton>
-        <InputsContainer show={showConfig}>
+        <InputsContainer>
           <label htmlFor="placement" className="dropdownLabel">
             Placement
           </label>
@@ -88,14 +62,14 @@ export const Config = () => {
 
           <input
             type="checkbox"
-            id="widePopup"
-            name="widePopup"
-            checked={wide}
+            id="hideHeader"
+            name="hideHeader"
+            checked={hideHeader}
             onChange={(e) => {
-              setWide(e.target.checked);
+              setHideHeader(e.target.checked);
             }}
           />
-          <label htmlFor="widePopup">Wide popup</label>
+          <label htmlFor="hideHeader">Hide header</label>
           <br />
 
           <input
@@ -112,18 +86,6 @@ export const Config = () => {
 
           <input
             type="checkbox"
-            id="hideHeader"
-            name="hideHeader"
-            checked={hideHeader}
-            onChange={(e) => {
-              setHideHeader(e.target.checked);
-            }}
-          />
-          <label htmlFor="hideHeader">Hide header</label>
-          <br />
-
-          <input
-            type="checkbox"
             id="disableClickAwayToClose"
             name="disableClickAwayToClose"
             checked={disableClickAwayToClose}
@@ -135,7 +97,69 @@ export const Config = () => {
             Disable clicking away to close
           </label>
           <br />
+
+          <input
+            type="checkbox"
+            id="widePopup"
+            name="widePopup"
+            checked={wide}
+            onChange={(e) => {
+              setWide(e.target.checked);
+            }}
+          />
+          <label htmlFor="widePopup">Wide popup</label>
+          <br />
+
+          <label htmlFor="arrayLength">Emoji array length</label>
+          <br />
+          <input
+            type="range"
+            id="arrayLength"
+            name="arrayLength"
+            min={0}
+            max={8}
+            value={emojiArrLength}
+            onChange={(e) => {
+              setEmojiArrLength(Number(e.target.value));
+            }}
+          />
+          <br />
         </InputsContainer>
+        <QuickReactions
+          onClickReaction={() => {}}
+          isVisible={showPopup}
+          onClose={() => setShowPopup(false)}
+          animation={animation}
+          reactionsArray={emojiArr1.slice(0, emojiArrLength)}
+          hideHeader={hideHeader}
+          hideCloseButton={hideCloseButton}
+          placement={placement}
+          wide={wide}
+          disableClickAwayToClose={disableClickAwayToClose}
+          trigger={
+            <GridItem hasTitle onClick={() => setShowPopup(!showPopup)}>
+              Click me!
+            </GridItem>
+          }
+        />
+        <Codeblock>
+          {`<QuickReactions
+  onClickReaction={() => {}}
+  isVisible={isVisible}
+  onClose={() => setIsVisible(false)}
+  trigger={
+    <button onClick={() => setIsVisible(!isVisible)}>
+      Click me!
+    </button>
+  }`}
+          {placement !== "bottom-start" ? `\n  placement={"${placement}"}` : ""}
+          {animation !== "drop" ? `\n  animation={"${animation}"}` : ""}
+          {hideHeader ? `\n  hideHeader` : ""}
+          {hideCloseButton ? `\n  hideCloseButton` : ""}
+          {disableClickAwayToClose ? `\n  disableClickAwayToClose` : ""}
+          {wide ? `\n  wide` : ""}
+          {`\n/>`}
+        </Codeblock>
       </ConfigContainer>
     </>
   );

--- a/example/src/components/showcaseComponents/config/ConfigStyles.ts
+++ b/example/src/components/showcaseComponents/config/ConfigStyles.ts
@@ -1,38 +1,34 @@
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 export const ConfigContainer = styled.div`
-  margin-top: 24px;
   // Same as grid.
   width: 638px;
+
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-row-gap: 12px;
+  grid-template-areas:
+    "config  button"
+    "codeblock  codeblock";
+
+  // Inputs container
+  div:first-of-type {
+    grid-area: config;
+  }
+  // Button
+  span:first-of-type {
+    grid-area: button;
+    place-self: center;
+  }
+  // Codeblock
+  div:nth-of-type(2) {
+    grid-area: codeblock;
+  }
 `;
 
-export const ConfigButton = styled.div`
-  cursor: pointer;
-  color: #0645ad;
-  font-size: 0.9rem;
-  :hover {
-    text-decoration: underline;
-  }
-  :active {
-    color: #faa700;
-  }
-`;
-
-export const InputsContainer = styled.div<{ show: boolean }>`
+export const InputsContainer = styled.div`
   background: white;
-  overflow: hidden;
-  margin-bottom: 10px;
-  width: 100%;
-  ${({ show }) =>
-    show
-      ? css`
-          height: 176px;
-        `
-      : css`
-          height: 0;
-        `}
-  transition: height 0.15s linear;
+
   label {
     margin-left: 4px;
     &.textInputLabel {

--- a/example/src/styles/AppStyles.ts
+++ b/example/src/styles/AppStyles.ts
@@ -2,9 +2,9 @@ import styled from "@emotion/styled";
 
 export const Body = styled.div`
   // Make space for the header.
-  margin-top: 40px;
+  margin-top: 68px;
   // 100vh - header - footer
-  min-height: calc(100vh - 40px - 26px);
+  min-height: calc(100vh - 68px - 26px);
 
   padding: 0 0 16px 0;
 `;


### PR DESCRIPTION
### Summary
* Implemented new `codeblock` component.
* Changed 'Customize it' title to 'Configure it'
* Added adjustable emoji array length.

### Why this change is needed
Allows users to see what the code looks like when configured. The code is also easily copied.

### What was done
* Implemented new `codeblock` component.
* Changed 'Customize it' title to 'Configure it'
* Added adjustable emoji array length with `<input type="range" />`
* Adjusted `Body` height to accommodate changes.