### PR TITLE
fix(example): on selecting emoji, popup wouldn't close in grid showcase

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "https://dylandbl.github.io/react-quick-reactions",
   "private": true,
   "dependencies": {

--- a/example/src/components/showcaseComponents/gridShowcase/GridShowcase.tsx
+++ b/example/src/components/showcaseComponents/gridShowcase/GridShowcase.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import QuickReactions from "react-quick-reactions";
 import { PlacementType } from "../../../../../lib/esm/types";
 import { gridEmojis } from "../../../utils/sampleData";
@@ -113,30 +113,33 @@ export const GridShowcase = () => {
     ""
   );
 
-  const handleVisibility = (title: string | null, show: boolean) => {
-    if (!title || show === null) return;
-    const gridItemsArrayCopy = gridItemsArray;
+  const handleVisibility = useCallback(
+    (title: string | null, show: boolean) => {
+      if (show === null) return;
+      const gridItemsArrayCopy = gridItemsArray;
 
-    // Get the index of the item to update and create an updated object.
-    const itemToUpdateIndex = gridItemsArrayCopy.findIndex(
-      (item) => item.title === title
-    );
-    const updatedItem = {
-      title: gridItemsArrayCopy[itemToUpdateIndex]?.title,
-      show,
-    };
+      // Get the index of the item to update and create an updated object.
+      const itemToUpdateIndex = gridItemsArrayCopy.findIndex(
+        (item) => item.title === title
+      );
+      const updatedItem = {
+        title: gridItemsArrayCopy[itemToUpdateIndex]?.title,
+        show,
+      };
 
-    // Remove the itemToUpdate from gridItemsArrayCopy.
-    const beforeSlice = gridItemsArrayCopy.slice(0, itemToUpdateIndex);
-    const afterSlice = gridItemsArrayCopy.slice(
-      itemToUpdateIndex + 1,
-      gridItemsArrayCopy.length
-    );
-    // Splice it into the new array.
-    const updatedArray = [...beforeSlice, updatedItem, ...afterSlice];
+      // Remove the itemToUpdate from gridItemsArrayCopy.
+      const beforeSlice = gridItemsArrayCopy.slice(0, itemToUpdateIndex);
+      const afterSlice = gridItemsArrayCopy.slice(
+        itemToUpdateIndex + 1,
+        gridItemsArrayCopy.length
+      );
+      // Splice it into the new array.
+      const updatedArray = [...beforeSlice, updatedItem, ...afterSlice];
 
-    setGridItemsArray(updatedArray);
-  };
+      setGridItemsArray(updatedArray);
+    },
+    [gridItemsArray]
+  );
 
   return (
     <>
@@ -148,13 +151,12 @@ export const GridShowcase = () => {
               key={item?.title + index.toString()}
               onClickReaction={(element) => {
                 setCurrentEmoji(element.textContent);
+                handleVisibility(item.title, false);
               }}
               isVisible={item.show}
               onClose={() => handleVisibility(item.title, false)}
               reactionsArray={gridEmojis}
               placement={item?.title ? item.title : undefined}
-              hideHeader
-              hideCloseButton
               trigger={
                 <GridItem
                   hasTitle={Boolean(item.title)}

--- a/example/src/utils/sampleData.ts
+++ b/example/src/utils/sampleData.ts
@@ -72,6 +72,10 @@ export const gridEmojis = [
     content: "👀",
   },
   {
+    name: "Partying",
+    content: "🥳",
+  },
+  {
     name: "Thinking",
     content: "🤔",
   },


### PR DESCRIPTION
### Summary
* Fixed oversight in making the popup close on reaction selection
* Set grid popups to default settings

### Why this change is needed
* The issue made the popups seem broken
* I think the popup should be shown in its default state. It can be made prettier in the configuration section.

### What was done
Added `handleVisibility(item.title, false);` to `onClickReaction`.