### PR TITLE
fix(example): default animation has changed to 'fade'

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "homepage": "https://dylandbl.github.io/react-quick-reactions",
   "private": true,
   "dependencies": {

--- a/example/src/components/showcaseComponents/config/Config.tsx
+++ b/example/src/components/showcaseComponents/config/Config.tsx
@@ -18,7 +18,7 @@ export const Config = () => {
   const [hideCloseButton, setHideCloseButton] = useState(false);
   const [wide, setWide] = useState(false);
   const [disableClickAwayToClose, setDisableClickAwayToClose] = useState(false);
-  const [animation, setAnimation] = useState<AnimationType>("drop");
+  const [animation, setAnimation] = useState<AnimationType>("fade");
   const [emojiArrLength, setEmojiArrLength] = useState(8);
 
   return (
@@ -153,7 +153,7 @@ export const Config = () => {
     </button>
   }`}
           {placement !== "bottom-start" ? `\n  placement={"${placement}"}` : ""}
-          {animation !== "drop" ? `\n  animation={"${animation}"}` : ""}
+          {animation !== "fade" ? `\n  animation={"${animation}"}` : ""}
           {hideHeader ? `\n  hideHeader` : ""}
           {hideCloseButton ? `\n  hideCloseButton` : ""}
           {disableClickAwayToClose ? `\n  disableClickAwayToClose` : ""}


### PR DESCRIPTION
### Summary
The default animation was changed from "drop" to "fade" in 2c464c2c7f76244e5838554e36ad9eb0a2028865.

### Why this change is needed
The code block made it seem as though "drop" was still the default, which is misleading.

### What was done
Changed the default `animation` state value, changed the conditional in the `return`.
Bumped the patch.