### PR TITLE
fix(style): popup header inheriting color from parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quick-reactions",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A popup emoji-reaction component for React.",
   "private": false,
   "main": "./lib/cjs/index.js",

--- a/src/styles/ReactionPopoverStyles.ts
+++ b/src/styles/ReactionPopoverStyles.ts
@@ -133,6 +133,7 @@ export const Header = styled.div`
   width: calc(100% - 16px);
   left: 8px;
   position: relative;
+  color: black;
 `;
 
 export const SelectionContainer = styled.div`


### PR DESCRIPTION
### Summary
The header was inheriting font colour from the parent, despite the rest of the popup not inheriting colour. 

### Why this change is needed
If the `color` of the parent is changed to a light colour, because the popup does not inherit its background colour, it can result in the header text being difficult or impossible to read against the popup's white background.

### What was done
Added `color` to the popup header's style.