### PR TITLE
refactor!: `onClickReaction` now passes ReactionObj

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const App = () => {
 | `hideCloseButton`                 | `boolean`                   | -             | Hides the close button.                                      |
 | `hideHeader`                      | `boolean`                   | -             | Hides the header                                             |
 | `isVisible`                       | `boolean`                   | `false`       | Determines popup visibility.                                 |
-| `onClickReaction`                 | `(value?: Element) => void` | -             | Function called when an emoji is clicked.                    |
+| `onClickReaction`                 | `(value: ReactionObj) => void` | -         | Function called when an emoji is clicked. Passes the emoji's `ReactionObj`. |
 | `onClose`                         | `() => void`                | -             | Function called on popup close.                              |
 | `placement`                       | [`PlacementType`](#placementtype) | `"bottom-start"` | Positions the popup relative to the `trigger`.      |
 | `reactionsArray`                  | [`ReactionObj[]`](#reactionobj) | -         | Array of emojis.                                             |

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "homepage": "https://dylandbl.github.io/react-quick-reactions",
   "private": true,
   "dependencies": {

--- a/example/src/components/header/Header.tsx
+++ b/example/src/components/header/Header.tsx
@@ -7,16 +7,18 @@ import {
 import { GitHubLogoSvg } from "../svgs/LogoSvgs";
 import { NpmLogoSvg } from "../svgs/LogoSvgs";
 import QuickReactions from "react-quick-reactions";
+import { ReactionObj } from "react-quick-reactions/lib/esm/types/index";
 import { useState } from "react";
 import { emojiArr2 } from "../../utils/sampleData";
 
 export const Header = () => {
   const [showHeaderQuickReactions, setShowHeaderQuickReactions] =
     useState(false);
-  const [selectedEmoji, setSelectedEmoji] = useState("" as string | null);
+  const [selectedEmoji, setSelectedEmoji] =
+    useState<ReactionObj["content"]>("");
 
-  const handleReactionSelect = (emoji?: Element) => {
-    if (emoji) setSelectedEmoji(emoji?.textContent);
+  const handleReactionSelect = (emoji?: ReactionObj) => {
+    if (emoji) setSelectedEmoji(emoji?.content);
     setShowHeaderQuickReactions(false);
   };
 

--- a/example/src/components/showcaseComponents/config/Config.tsx
+++ b/example/src/components/showcaseComponents/config/Config.tsx
@@ -126,7 +126,7 @@ export const Config = () => {
           <br />
         </InputsContainer>
         <QuickReactions
-          onClickReaction={() => {}}
+          onClickReaction={(item) => console.log(item)}
           isVisible={showPopup}
           onClose={() => setShowPopup(false)}
           animation={animation}

--- a/example/src/components/showcaseComponents/gridShowcase/GridShowcase.tsx
+++ b/example/src/components/showcaseComponents/gridShowcase/GridShowcase.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useState } from "react";
 import QuickReactions from "react-quick-reactions";
-import { PlacementType } from "../../../../../lib/esm/types";
 import { gridEmojis } from "../../../utils/sampleData";
 import { Grid, GridItem, EmojiDisplay } from "./GridShowcaseStyles";
+import {
+  ReactionObj,
+  PlacementType,
+} from "react-quick-reactions/lib/esm/types/index";
 
 export const gridItems: { title: PlacementType | null; show: boolean }[] = [
   {
@@ -109,9 +112,7 @@ export const gridItems: { title: PlacementType | null; show: boolean }[] = [
 
 export const GridShowcase = () => {
   const [gridItemsArray, setGridItemsArray] = useState(gridItems);
-  const [currentEmoji, setCurrentEmoji] = useState<string | null | undefined>(
-    ""
-  );
+  const [currentEmoji, setCurrentEmoji] = useState<ReactionObj["content"]>("");
 
   const handleVisibility = useCallback(
     (title: string | null, show: boolean) => {
@@ -150,7 +151,7 @@ export const GridShowcase = () => {
             <QuickReactions
               key={item?.title + index.toString()}
               onClickReaction={(element) => {
-                setCurrentEmoji(element.textContent);
+                setCurrentEmoji(element.content);
                 handleVisibility(item.title, false);
               }}
               isVisible={item.show}

--- a/example/src/components/showcaseComponents/photoShoot/Comment.tsx
+++ b/example/src/components/showcaseComponents/photoShoot/Comment.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import QuickReactions from "react-quick-reactions";
+import { ReactionObj } from "react-quick-reactions/lib/esm/types/index";
 import { commentEmojis } from "../../../utils/sampleData";
 import { SmileSvg } from "../../svgs/SmileSvg";
 import {
@@ -35,12 +36,12 @@ export const CustomComment = ({
   const [visible, setVisible] = useState(false);
   const [reactionArrayState, setReactionArrayState] = useState(reactionArray);
 
-  const handleClickReaction = (emojiElement?: Element) => {
+  const handleClickReaction = (emojiElement?: ReactionObj) => {
     setVisible(false);
     const reactionArrayStateCopy = reactionArrayState;
 
     const index = reactionArrayStateCopy.findIndex(
-      (item) => item.content === emojiElement?.textContent
+      (item) => item.content === emojiElement?.content
     );
 
     reactionArrayStateCopy[index].count += 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quick-reactions",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A popup emoji-reaction component for React.",
   "private": false,
   "main": "./lib/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quick-reactions",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "A popup emoji-reaction component for React.",
   "private": false,
   "main": "./lib/cjs/index.js",

--- a/src/components/ReactionPopover/ReactionPopover.tsx
+++ b/src/components/ReactionPopover/ReactionPopover.tsx
@@ -113,7 +113,7 @@ export const ReactionPopover = (props: PopoverProps) => {
                 }
                 key={item?.name + "-" + index}
                 id={item?.id}
-                onClick={(e) => onClickReaction(e.target as Element)}
+                onClick={() => onClickReaction(item)}
                 onMouseEnter={
                   changeHeaderOnReactionElemHover
                     ? () => setPopoverHeader(item?.name)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,8 @@
-type ReactionObj = {
+export type ReactionObj = {
   id?: string;
   name: string;
   content: string | JSX.Element;
+  [key: string]: any;
 };
 
 export type PlacementType =
@@ -31,7 +32,7 @@ export interface RQRProps {
   hideCloseButton?: boolean;
   hideHeader?: boolean;
   isVisible: boolean;
-  onClickReaction: (event: Element) => void;
+  onClickReaction: (reaction: ReactionObj) => void;
   onClose: () => void;
   outerDivClassName?: string;
   placement?: PlacementType;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,6 @@ export type ReactionObj = {
   id?: string;
   name: string;
   content: string | JSX.Element;
-  [key: string]: any;
 };
 
 export type PlacementType =


### PR DESCRIPTION
### Summary
* Changed `onClickReaction` to pass `ReactionObj` instead of `Element`, as it will contain all the object's relevant info.
* `index.ts` now exports `ReactionObj` - can be imported from `"react-quick-reactions/lib/esm/types/index"`.
* Implemented the changes into `/example`.

### Why this change is needed
Passing the element meant that only the data contained in the emoji's `<span>` could be received; Passing the object ensures all the emoji's relevant data is passed.

### What was done
Changed `onClickReaction` type to `(reaction: ReactionObj) => void`, implemented the new change into `/example`.